### PR TITLE
Change $LANG to C.UTF-8

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -59,7 +59,7 @@ command+=" /usr/bin/env -i"
 command+=" HOME=/root"
 command+=" PATH=/usr/local/sbin:/usr/local/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/games:/usr/local/games"
 command+=" TERM=\$TERM"
-command+=" LANG=\$LANG"
+command+=" LANG=C.UTF-8"
 command+=" /bin/bash --login"
 com="\$@"
 if [ -z "\$1" ];then


### PR DESCRIPTION
default termux locale is en_US.UTF-8
but in guest Ubuntu:
`locale -a` shows Ubuntu has 3 available locales (core images doesn't have i18n)
```
C
C.UTF-8
POSIX
```
setting $LANG to C.UTF-8 avoids encoding falling back to latin1. It would be able to decode and show asian characters so that `ls` command would not produce odd output for non-ascii filenames. programs that relies on $LANG could behave as expected
this change could also get rid of the locale error in `apt install`
---------------
some questions:
1. I'm just wondering, why the script is binding /system and /sys to guest fs? /proc and /dev is necessary, but it seems that /system and /sys is not
2. about the commented line:
#command +=" -b /data/data/com.termux/files/home"
it would be better to be
#command +=" -b /data/data/com.termux/files/home:/home" (/home is an empty directory in ubuntu-fs)
so users who uncommented this line would not get confused by the path in guest fs.